### PR TITLE
Fixed lock-up when issuing "monitor stop" to control port

### DIFF
--- a/dataxfer.c
+++ b/dataxfer.c
@@ -4119,7 +4119,7 @@ data_monitor_stop(struct controller_info *cntlr,
 
     LOCK(ports_lock);
     curr = ports;
-    while (curr) {
+    while (curr != NULL) {
 	if (curr == port) {
 	    LOCK(port->lock);
 	    port->net_monitor = NULL;
@@ -4127,6 +4127,7 @@ data_monitor_stop(struct controller_info *cntlr,
 	    UNLOCK(port->lock);
 	    break;
 	}
+        curr = curr->next;
     }
     UNLOCK(ports_lock);
 }


### PR DESCRIPTION
port_info_t (ports) linked list was not being walked in while loop

Signed-off-by: David Thornley <david.thornley@touchstargroup.com>