### PR TITLE
configure.ac: use pkg-config to retrieve gensio dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,10 +40,11 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_STDC_HEADERS
 AC_CHECK_LIB(nsl,main)
 
-AC_CHECK_HEADER(gensio/gensio.h, [],
-   [AC_MSG_ERROR([gensio.h not found, please install gensio dev package])])
-AC_CHECK_LIB(gensio, str_to_gensio, [],
-   [AC_MSG_ERROR([libgensio won't link, please install gensio dev package])])
+PKG_CHECK_MODULES(GENSIO, libgensio, [LIBS=$GENSIO_LIBS],
+   [AC_CHECK_HEADER(gensio/gensio.h, [],
+      [AC_MSG_ERROR([gensio.h not found, please install gensio dev package])])
+   AC_CHECK_LIB(gensio, str_to_gensio, [],
+      [AC_MSG_ERROR([libgensio won't link, please install gensio dev package])])])
 
 AC_CHECK_HEADER(yaml.h, [],
    [AC_MSG_ERROR([yaml.h not found, please install libyaml dev package])])


### PR DESCRIPTION
gensio can optionally depends on openssl so use pkg-config to retrieve
those static dependencies thanks to libgensio.pc

This will avoid the following build failure when building statically:

```
checking gensio/gensio.h usability... yes
checking gensio/gensio.h presence... yes
checking for gensio/gensio.h... yes
checking for str_to_gensio in -lgensio... no
configure: error: libgensio won't link, please install gensio dev package
```

Fixes:
 - http://autobuild.buildroot.org/results/f15cf961ddaf849987afce01ede0e3d1e77a0fc0

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>