### PR TITLE
modify code to fix Warning code in dataxfer.c

### DIFF
--- a/dataxfer.c
+++ b/dataxfer.c
@@ -1556,7 +1556,7 @@ process_str(port_info_t *port, net_info_t *netcon,
 	    /* \Y -> year */
 	    case 'Y':
 	    {
-		char d[10], *dp;
+		char d[16], *dp;
 		snprintf(d, sizeof(d), "%d", time->tm_year + 1900);
 		for (dp = d; *dp; dp++)
 		    op(data, *dp);
@@ -1628,7 +1628,7 @@ process_str(port_info_t *port, net_info_t *netcon,
 	    /* \h -> hour (12-hour time) */
 	    case 'h':
 	    {
-		char d[10], *dp;
+		char d[16], *dp;
 		int v;
 
 		v = time->tm_hour;


### PR DESCRIPTION
Dear Sir,

I have fixed the following warning message that is modified size of String.

----------------------------------------------------------
ser2net](3.5.x)$ make
  CC       controller.o
  CC       dataxfer.o
dataxfer.c: In function ‘process_str.isra.13’:
dataxfer.c:1639:27: warning: ‘%2.2d’ directive output may be truncated writing between 2 and 11 bytes into a region of size 10 [-Wformat-truncation=]
   snprintf(d, sizeof(d), "%2.2d", v);
                           ^~~~~
dataxfer.c:1639:26: note: directive argument in the range [-2147483648, 2147483635]
   snprintf(d, sizeof(d), "%2.2d", v);
                          ^~~~~~~
dataxfer.c:1639:3: note: ‘snprintf’ output between 3 and 12 bytes into a destination of size 10
   snprintf(d, sizeof(d), "%2.2d", v);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
dataxfer.c:1560:27: warning: ‘%d’ directive output may be truncated writing between 1 and 11 bytes into a region of size 10 [-Wformat-truncation=]
   snprintf(d, sizeof(d), "%d", time->tm_year + 1900);
                           ^~
dataxfer.c:1560:26: note: directive argument in the range [-2147481748, 2147483647]
   snprintf(d, sizeof(d), "%d", time->tm_year + 1900);
                          ^~~~
dataxfer.c:1560:3: note: ‘snprintf’ output between 2 and 12 bytes into a destination of size 10
   snprintf(d, sizeof(d), "%d", time->tm_year + 1900);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  CC       devcfg.o
  CC       readconfig.o
  CC       selector.o
  CC       ser2net.o
  CC       utils.o
  CC       telnet.o
  CC       buffer.o
  CC       sol.o
  CC       led.o
  CC       led_sysfs.o
  CCLD     ser2net
