### PR TITLE
configure.ac: add missing use_pthreads_set variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,8 +5,10 @@ AM_PROG_AR
 AM_PROG_LIBTOOL
 
 use_pthreads=yes
+use_pthreads_set=false
 AC_ARG_WITH(pthreads,
 [  --with-pthreads=yes|no      Use pthreads or not.],
+    use_pthreads_set=true
     if test "x$withval" = "xyes"; then
       use_pthreads=yes
     elif test "x$withval" = "xno"; then


### PR DESCRIPTION
You added these in gensio [here](https://github.com/cminyard/gensio/commit/8c008d596c30f65c679e063097f99a03cc6f7e01) but I think you forgot them in ser2net.