### PR TITLE
configure.ac: fix USE_PTHREADS define

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,19 +16,16 @@ AC_ARG_WITH(pthreads,
     fi,
 )
 
-USE_PTHREADS=0
 if test "x$use_pthreads" != "xno"; then
    AX_PTHREAD(
       [LIBS="$LIBS $PTHREAD_LIBS"
        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
        CC="$PTHREAD_CC"
-       USE_PTHREADS=1],
+       AC_DEFINE([USE_PTHREADS], [], [Enable multithreaded support])]],
       [if $use_pthreads_set; then
           AC_MSG_FAILURE([--with-pthreads was given, but no working pthread library was found])
        fi])
 fi
-AC_DEFINE_UNQUOTED([USE_PTHREADS], [$USE_PTHREADS],
-		   [Enable multithreaded support])
 
 AC_ARG_WITH(sysfs-led-support,
  [  --with-sysfs-led-support   Enable LED support (Linux only)],

--- a/ser2net.c
+++ b/ser2net.c
@@ -293,7 +293,7 @@ static struct gensio_lock *config_lock;
 
 static struct gensio_lock *maint_lock;
 
-#if USE_PTHREADS
+#ifdef USE_PTHREADS
 static int in_config_read = 0;
 
 int ser2net_wake_sig = SIGUSR1;
@@ -544,7 +544,7 @@ sig_fd_read_handler(int fd, void *cb_data)
 	shutdown_cleanly();
 
     if (reread_config && !in_shutdown) {
-#if USE_PTHREADS
+#ifdef USE_PTHREADS
 	thread_reread_config_file();
 #else
 	reread_config_file();


### PR DESCRIPTION
Without this change headers within a USE_PTHREADS ifdef statement are still included.

Fixes:
```
ser2net.c:51:10: fatal error: pthread.h: No such file or directory
 #include <pthread.h>
          ^~~~~~~~~~~
compilation terminated.
```

This is tested using a toolchain without pthreads. I copied this implementation from gensio.