### PR TITLE
Add support for sendon

### DIFF
--- a/readconfig.c
+++ b/readconfig.c
@@ -448,6 +448,7 @@ struct default_data defaults[] = {
     { "closestr",	GENSIO_DEFAULT_STR,	.def.strval = NULL },
     { "closeon",	GENSIO_DEFAULT_STR,	.def.strval = NULL },
     { "banner",		GENSIO_DEFAULT_STR,	.def.strval = NULL },
+    { "sendon",		GENSIO_DEFAULT_STR,	.def.strval = NULL },
     { NULL }
 };
 

--- a/ser2net.yaml
+++ b/ser2net.yaml
@@ -225,6 +225,7 @@ define: &confver 1.0
 #     chardelay-scale: 20
 #     chardelay-min: 1000
 #     chardelay-max: 20000
+#     sendon: ""
 #     dev-to-net-bufsize: 64
 #     net-to-dev-bufsize: 64
 #     max-connections: 1

--- a/ser2net.yaml.5
+++ b/ser2net.yaml.5
@@ -273,6 +273,12 @@ sets the maximum delay that ser2net will wait, in microseconds, before
 sending the data.  The default value is 20000.  This keeps the connection
 working smoothly at slow speeds.
 
+.I sendon: <sendon string>
+If the given string is seen coming from the connector side of the connection,
+sends buffered data up to and including the string. Disabled by default. As an
+example, this can be set to \r\n with appropriate chardelay settings to send
+one line at a time.
+
 .I dev-to-net-bufsize: <number>
 sets the size of the buffer reading from the connecting gensio and writing
 to the accepted gensio.


### PR DESCRIPTION
Adds a new option, sendon, that has a string value. When the string is
seen from the connector, buffered data up to and including the string
will be sent.

Signed-off-by: Scott Bertin <scott.bertin@ametek.com>