### PR TITLE
sendon: Fix back-to-back delimiters

### DIFF
--- a/dataxfer.c
+++ b/dataxfer.c
@@ -1052,6 +1052,7 @@ handle_dev_read(port_info_t *port, int err, unsigned char *buf,
 		if (port->sendon_pos >= port->sendon_len) {
 		    count = i + 1;
 		    send_now = true;
+		    port->sendon_pos = 0;
 		    break;
 		}
 	    } else {


### PR DESCRIPTION
When two delimiters occurred back-to-back only the first one was
recognized. This resets the position on a match so the second one will
be recognized also.

Signed-off-by: Scott Bertin <scott.bertin@ametek.com>