### PR TITLE
port.h: include <sys/time.h>

### DIFF
--- a/port.h
+++ b/port.h
@@ -9,6 +9,7 @@
 #define PORT
 
 #include <netdb.h>
+#include <sys/time.h>
 #include "gbuf.h"
 #include "absout.h"
 


### PR DESCRIPTION
Include <sys/time.h> to avoid the following build failure on musl:

```
port.h:361:29: warning: 'struct timeval' declared inside parameter list will not be visible outside of this definition or declaration
     const char *str, struct timeval *tv,
                             ^~~~~~~
portconfig.c: In function 'myconfig':
portconfig.c:586:9: error: variable 'tv' has initializer but incomplete type
  struct timeval tv = { 0, 0 };
         ^~~~~~~
```
Fixes:
 - http://autobuild.buildroot.org/results/4c0b238186cb2fb2d81807ce006945594f92b2cd

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>