### PR TITLE
Add PAM authentication support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,26 @@ if test "x$use_pthreads" != "xno"; then
        fi])
 fi
 
+use_pam=yes
+AC_ARG_WITH(pam,
+[  --with-pam=yes|no           Support PAM authentication or not.],
+    if test "x$withval" = "xyes"; then
+      use_pam=yes
+    elif test "x$withval" = "xno"; then
+      use_pam=no
+    fi,
+)
+
+if test "x$use_pam" != "xno"; then
+    AC_CHECK_HEADER(security/pam_appl.h, [],
+	[AC_MSG_ERROR(["security/pam_appl.h not, please install libpam dev package or disable PAM support"])]
+    )
+    AC_CHECK_LIB(pam, pam_start, [],
+	[AC_MSG_ERROR([libpam won't link, please install libpam dev package or disable PAM support"])]
+    )
+    AC_DEFINE([USE_PAM], [], [Enable PAM support])
+fi
+
 AC_ARG_WITH(sysfs-led-support,
  [  --with-sysfs-led-support   Enable LED support (Linux only)],
  sysfs_led_support_flag="$withval",

--- a/controller.c
+++ b/controller.c
@@ -44,6 +44,7 @@
 static struct gensio_lock *cntlr_lock;
 static struct gensio_accepter *controller_accepter;
 static char *controller_authdir;
+static char *controller_pamauth;
 static struct gensio_waiter *accept_waiter;
 
 static int max_controller_ports = 4;	/* How many control connections
@@ -1074,7 +1075,10 @@ controller_acc_child_event(struct gensio_accepter *accepter, void *user_data,
 	return controller_acc_new_child(data);
 
     default:
-	return handle_acc_auth_event(controller_authdir, NULL, event, data);
+	return handle_acc_auth_event(
+	    controller_authdir, controller_pamauth,
+	    NULL, event, data
+	);
     }
 }
 
@@ -1106,6 +1110,9 @@ controller_init(char *controller_port, const char * const *options,
     if (find_default_str("authdir-admin", &controller_authdir))
 	goto out_nomem;
 
+    if (find_default_str("pamauth-admin", &controller_pamauth))
+	goto out_nomem;
+
     for (i = 0; options && options[i]; i++) {
 	if (gensio_check_keyvalue(options[i], "authdir-admin", &val) > 0) {
 	    char *s = strdup(val);
@@ -1115,6 +1122,16 @@ controller_init(char *controller_port, const char * const *options,
 	    if (controller_authdir)
 		free(controller_authdir);
 	    controller_authdir = s;
+	    continue;
+	}
+	if (gensio_check_keyvalue(options[i], "pamauth-admin", &val) > 0) {
+	    char *s = strdup(val);
+
+	    if (!s)
+		goto out_nomem;
+	    if (controller_pamauth)
+		free(controller_pamauth);
+	    controller_pamauth = s;
 	    continue;
 	}
 	if (eout)

--- a/defaults.c
+++ b/defaults.c
@@ -71,6 +71,8 @@ static struct default_data defaults[] = {
 						DATAROOT "/ser2net/auth" },
     { "authdir-admin",	GENSIO_DEFAULT_STR,	.def.strval =
 						SYSCONFDIR "/ser2net/auth" },
+    { "pamauth",	GENSIO_DEFAULT_STR,	.def.strval = NULL },
+    { "pamauth-admin",	GENSIO_DEFAULT_STR,	.def.strval = NULL },
     { "allowed-users",	GENSIO_DEFAULT_STR,	.def.strval = NULL },
     { "signature",	GENSIO_DEFAULT_STR,	.def.strval = "ser2net" },
     { "openstr",	GENSIO_DEFAULT_STR,	.def.strval = NULL },

--- a/port.c
+++ b/port.c
@@ -271,8 +271,8 @@ handle_port_child_event(struct gensio_accepter *accepter, void *user_data,
 	return port_new_con(port, data);
 
     default:
-	return handle_acc_auth_event(port->authdir, port->allowed_users,
-				     event, data);
+	return handle_acc_auth_event(port->authdir, port->pamauth,
+	    port->allowed_users, event, data);
     }
 }
 

--- a/port.h
+++ b/port.h
@@ -326,6 +326,11 @@ struct port_info
     char *authdir;
 
     /*
+     * Enable PAM authentication
+     */
+    char *pamauth;
+
+    /*
      * List of authorized users.  If NULL, all users are authorized.
      * If no allowed users are specified, the default is taken.
      */

--- a/portconfig.c
+++ b/portconfig.c
@@ -586,6 +586,15 @@ myconfig(port_info_t *port, struct absout *eout, const char *pos)
 	if (port->authdir)
 	    free(port->authdir);
 	port->authdir = fval;
+    } else if (gensio_check_keyvalue(pos, "pamauth", &val) > 0) {
+	fval = strdup(val);
+	if (!fval) {
+	    eout->out(eout, "Out of memory allocating pamauth");
+	    return -1;
+	}
+	if (port->pamauth)
+	    free(port->pamauth);
+	port->pamauth = fval;
     } else if (gensio_check_keyvalue(pos, "allowed-users", &val) > 0) {
 	rv = add_allowed_users(&port->allowed_users, val, eout);
 	if (rv)
@@ -830,6 +839,8 @@ init_port_data(port_info_t *port)
     port->connector_retry_time = find_default_int("connector-retry-time");
     port->accepter_retry_time = find_default_int("accepter-retry-time");
     if (find_default_str("authdir", &port->authdir))
+	return ENOMEM;
+    if (find_default_str("pamauth", &port->pamauth))
 	return ENOMEM;
     if (find_default_str("allowed-users", &port->default_allowed_users))
 	return ENOMEM;

--- a/ser2net.h
+++ b/ser2net.h
@@ -65,7 +65,7 @@ int scan_int(const char *str);
 /*
  * Handle authorization events from accepters.
  */
-int handle_acc_auth_event(const char *authdir,
+int handle_acc_auth_event(const char *authdir, const char *pamauth,
 			  const struct gensio_list *allowed_users,
 			  int event, void *data);
 

--- a/ser2net.yaml
+++ b/ser2net.yaml
@@ -273,6 +273,7 @@ define: &confver 1.0
 #     net-to-dev-bufsize: 64
 #     max-connections: 1
 #     authdir: <authentication directory>
+#     pamauth: ""
 #     allowed-users: <space separated list of names>
 #     remaddr: <remote address>
 #     connback: <remote connector string>

--- a/ser2net.yaml.5
+++ b/ser2net.yaml.5
@@ -433,6 +433,9 @@ port uness all connect backs have been established.
 .I authdir: <directory string>
 specified the authentication directory to use for this connection.
 
+.I pamauth: <service name>
+Enables PAM authentication and sets the PAM service name.
+
 .I allowed-users: <space separated list of names>
 The users that are allowed to use this connections.  This has no
 meaning if authentication is not enabled on the connections.  If this
@@ -516,7 +519,7 @@ options:
 .RE
 .RE
 
-A rotator has three possible options, "authdir", "allowed-users", and
+A rotator has four possible options, "authdir", "pamauth", "allowed-users", and
 "accepter-retry-time", both same as connections.
 
 You should use YAML aliases for the connections.
@@ -658,6 +661,13 @@ details.
 The authentication directory for ser2net for admin connections.  The
 "ADMIN_CONNECTIONS" for more details.
 .TP
+.B pamauth: <NULL>
+The PAM service name for ser2net PAM authentication (<NULL> for disabled).
+.TP
+.B pamauth-admin: <NULL>
+The PAM service name for ser2net admin connection PAM authentication (<NULL>
+for disabled). See "ADMIN_CONNECTIONS" for more details.
+.TP
 .B mdns-interface: -1
 The default mDNS interface.
 .TP
@@ -687,10 +697,10 @@ options:
 .RE
 .RE
 
-The only option available is "authdir-admin", which sets the
-authentication directory for the admin port.  This is different than
-the authdir for connections and rotators, though you can set it to the
-same value.
+The only options available are "authdir-admin", which sets the authentication
+directory for the admin port and "pamauth-admin" which sets the PAM service
+name and enables PAM authentication. Both are different than "authdir" resp.
+"pamauth" for connections, though you can set it to the same value.
 
 .SH LEDS
 .B ser2net
@@ -1117,14 +1127,18 @@ If you have not connected to that server/port before, gtlssh will
 ask you to verify it, much like ssh does.  If certificates, IP
 address, etc. change, gtlssh will tell you about it.
 
-If you do not want to use a certificate (certificates are certainly
-preferred, but may not alway be workable) you can use a password
-login, too.  Put a password in authdir/username/password.  When
-you connect with gtlssh, if certificate validate fails, you will
-be prompted for the password.  If it matches the first line in the
-password file, then authentication will succeed.  You must set
-enable-password in the certauth gensio options for passwords
-to work.
+If you do not want to use a certificate (certificates are certainly preferred,
+but may not always be workable) you can use a password login, too. You must set
+enable-password in the certauth gensio options for passwords to work.  When you
+connect with gtlssh, if certificate validate fails, you will be prompted for
+the password. Password authentication can be performed in two different ways.
+Both are mutually exclusive,  depending on whether pamauth is set or not:
+.IP \(bu
+To authenticate using the PAM library set the PAM service name via pamauth
+option.
+.IP \(bu
+Put a password in authdir/username/password. If it matches the first line in
+the password file and pamauth is not set, then authentication will succeed.
 .SS "AUTHENTICATION AND ROTATORS"
 Rotators are a special case.  BE CAREFUL.  A rotator has its own
 authentication.  If you set up authentication on a port that is


### PR DESCRIPTION
Hello @cminyard ,

this PR addresses https://github.com/cminyard/gensio/issues/26 . I think I was on the wrong track the whole time, since the certauth only collects the username and password but leaves the actual password verification to the server application. Therefore I figured this should be the place to PAM authentication into the application which is ser2net in our case. Also it is *a lot* less code to maintain.

Currently I am not done yet. But I want to kindly ask for your opinion before going further in this direction as it's still our goal to merge this into mainline ser2net.

### Test setup
#### Server
```sh
❯ cat ser2net.yaml 
connection: &test-server
  accepter: certauth(enable-password),ssl(key=ser2net.key,cert=ser2net.crt),tcp,2013
  connector: serialdev,/dev/serial/by-id/usb-FTDI_TTL232R-3V3_FTASU5TK-if00-port0,115200N81
  options:
    banner: ser2net Echo Server\r\n
    mdns: false
    authdir: .
    pamauth: true
❯ cat pam.d/other 
auth     required /usr/lib/x86_64-linux-gnu/pam_wrapper/pam_matrix.so passdb=/data/projects/ser2net-pam/ser2net-test/pam.d/passdb
account  required /usr/lib/x86_64-linux-gnu/pam_wrapper/pam_matrix.so passdb=/data/projects/ser2net-pam/ser2net-test/pam.d/passdb
password required /usr/lib/x86_64-linux-gnu/pam_wrapper/pam_matrix.so passdb=/data/projects/ser2net-pam/ser2net-test/pam.d/passdb
session  required /usr/lib/x86_64-linux-gnu/pam_wrapper/pam_matrix.so passdb=/data/projects/ser2net-pam/ser2net-test/pam.d/passdb
❯ cat pam.d/passdb 
bob:secret:ser2net
❯ LD_PRELOAD=libpam_wrapper.so PAM_WRAPPER=1 PAM_WRAPPER_SERVICE_DIR=$PWD/pam.d ser2net -d -c ./ser2net.yaml
Unable to start mdns: Operation not supported
```
#### Client
```sh
❯ gtlssh -p 2013 --cadir . --nomux bob@localhost   
Password: secret

ser2net Echo Server

embedded device login: 
```

### TODO
- [x] Fix TODOs
- [x] Add conditional to build without PAM support
- [x] Documentation