### PR TITLE
Update ser2net.yaml.5

### DIFF
--- a/ser2net.yaml.5
+++ b/ser2net.yaml.5
@@ -129,7 +129,7 @@ telnet with RFC2217 support, you can do:
 .RS
 connection: &toS0telnet
 .RS
-accepter: telnet(rfc2217)tcp,1234
+accepter: telnet(rfc2217),tcp,1234
 .br
 connector: serialdev,/dev/ttyS0,local
 .RE


### PR DESCRIPTION
The example for using RFC2217 is missing a comma, and not a grammatical comma- one that makes the configuration give an error.