### PR TITLE
Implemented must-not-fail config option to exit ser2net

### DIFF
--- a/defaults.c
+++ b/defaults.c
@@ -47,6 +47,7 @@ struct default_data
 static struct default_data defaults[] = {
     /* All port types */
     { "telnet-brk-on-sync",GENSIO_DEFAULT_BOOL,.def.intval = 0 },
+    { "must-not-fail",	GENSIO_DEFAULT_BOOL,	.def.intval = 0 },
     { "kickolduser",	GENSIO_DEFAULT_BOOL,	.def.intval = 0 },
     { "chardelay",	GENSIO_DEFAULT_BOOL,	.def.intval = 1 },
     { "chardelay-scale",GENSIO_DEFAULT_INT,	.min = 1, .max = 1000,

--- a/port.h
+++ b/port.h
@@ -269,6 +269,9 @@ struct port_info
     /* Send a break if we get a sync command? */
     bool telnet_brk_on_sync;
 
+    /* If the connection fails to open during start-up then exit ser2net */
+    bool must_not_fail_mode;
+
     /* kickolduser mode */
     bool kickolduser_mode;
 

--- a/ser2net.yaml
+++ b/ser2net.yaml
@@ -291,6 +291,7 @@ define: &confver 1.0
 #     closeon:
 #     connector-retry-time: 10
 #     accepter-retry-time: 10
+#     must-not-fail: false
 #     mdns: false
 #     mdns-interface: -1
 #     mdns-nettype: unspec

--- a/ser2net.yaml.5
+++ b/ser2net.yaml.5
@@ -463,6 +463,10 @@ is not set or defaulted, all users are allowed.  If this is set to an
 empty set of users, then no users are allowed.  This may be specified
 more than once, each one adds more users.
 
+.I must-not-fail: true|false
+If this connection fails during startup then ser2net will exit,
+forcing the service to go offline.
+
 .I mdns: true|false
 Enables/disables mdns support for the connection.  If you set this and
 mdns is available, ser2net will create a service on mdns for the port.


### PR DESCRIPTION
I have added a `must-not-fail` config option to ser2net. The purpose of this config option is to force ser2net to completely exit (with return code 1) if starting the new port fails at all. The flag is off by default so it is fully backwards compatible.

This feature was originally suggested in #79.

This fixes the common issue where a connection defined in ser2net will fail, ser2net is functionally dead, but systemd sees it as active.

In my testing I've found this feature works as expected:
* Systemd will fail to start the service on boot due to the underlying issue
* Systemd will restart the service automatically
* I found I need to set `RestartSec=10` otherwise it restarts too quickly.

Why do this?
---
I've tried all the systemd modifications suggested in various past issues. While this has worked for me in the past none of the fixes are now working for me. I understand this is not ser2net's fault but the reality is that it's hard to have ser2net work reliably without this optional flag.

I've tried various things e.g. those discussed in #52
* Targeting `After and wants=network-online.target`
* Targeting `After and wants=multi-user.target`
* Adding `After=dev-ttyUSB0.device`
* Adding a systemd timer of up to 1min to slow down the startup of ser2net.

Some of these work sometimes, but not always. Allowing systemd to know that the service is not running properly is the only way I've been able to have ser2net start reliably. The problem is that we don't know exactly how long we need to wait - so retrying multiple times is important.

The only other potential fix I could see is changing behaviour of `accepter-retry-time` to allow it to retry multiple times.

A systemd definition like so worked for me (note this is based on paths when compiled from source - using /usr/local/):
```
[Unit]
Description=Allows network connections to serial ports
Documentation=man:ser2net(8)
After=network.target
After=network-online.target
Wants=network-online.target

[Service]
EnvironmentFile=-/etc/default/ser2net
ExecStart=/usr/local/sbin/ser2net -n -c /etc/ser2net/ser2net.yaml -P /run/ser2net.pid $OPTIONS
Restart=always
#Without this it tries to restart too quick
RestartSec=10

[Install]
#Dont want to wait for this on boot. Might be OK to leave this?
#WantedBy=multi-user.target
Alias=ser2net.service
```


