### PR TITLE
fix typo reponse => response in ser2net.8

### DIFF
--- a/ser2net.8
+++ b/ser2net.8
@@ -234,7 +234,7 @@ form:
     parms: [ parm1 [, parm2 [...]]]
   ...
 
-The id is optional and will just be returned in the reponse.  The
+The id is optional and will just be returned in the response.  The
 parms are optional, too, unless the command requires them.  Extra
 parms are ignored, along with unknown keys in the main mapping.
 


### PR DESCRIPTION
this fixes a typo in the ser2net.8 manual page