### PR TITLE
Add support for a connect LED in ser2net

### DIFF
--- a/dataxfer.c
+++ b/dataxfer.c
@@ -126,12 +126,16 @@ report_newcon(port_info_t *port, net_info_t *netcon)
     if (!net_raddr_str(netcon->net, netcon->remaddr, sizeof(netcon->remaddr)))
 	strcpy(netcon->remaddr, "*unknown*");
     cntlr_report_conchange("new connection", port->name, netcon->remaddr);
+	if (port->led_conn)
+	    led_enable(port->led_conn, 1);
 }
 
 void
 report_disconnect(port_info_t *port, net_info_t *netcon)
 {
     cntlr_report_conchange("disconnect", port->name, netcon->remaddr);
+	if (port->led_conn)
+	    led_enable(port->led_conn, 0);
 }
 
 static void

--- a/led.c
+++ b/led.c
@@ -234,6 +234,12 @@ free_leds(void)
 }
 
 int
+led_enable(struct led_s *led, int value)
+{
+    return led->driver->enable(led->drv_data, value);
+}
+
+int
 led_flash(struct led_s *led)
 {
     return led->driver->flash(led->drv_data);

--- a/led.h
+++ b/led.h
@@ -58,6 +58,9 @@ struct led_driver_s {
     /* required: called when data transfer should be signaled */
     int (*flash)(void *drv_data);
 
+    /* required: turn led on or off */
+    int (*enable)(void *drv_data, int value);
+
     /* optional: called during deinitialization, could switch the LED off */
     int (*deconfigure)(void *drv_data);
 };
@@ -80,6 +83,9 @@ void free_led(struct led_s *led);
 
 /* Free all registered LEDs in the system */
 void free_leds(void);
+
+/* Turn LED on / off */
+int led_enable(struct led_s *led, int value);
 
 /* Flash the given LED */
 int led_flash(struct led_s *led);

--- a/port.h
+++ b/port.h
@@ -337,6 +337,10 @@ struct port_info
      */
     struct led_s *led_tx;
     struct led_s *led_rx;
+    /*
+     * LED to light on connect
+     */
+    struct led_s *led_conn;
 
     /*
      * Directory that has authentication info.

--- a/portconfig.c
+++ b/portconfig.c
@@ -333,6 +333,8 @@ finish_free_port(port_info_t *port)
 	free_led(port->led_rx);
     if (port->led_tx)
 	free_led(port->led_tx);
+    if (port->led_conn)
+	free_led(port->led_conn);
 #ifdef DO_MDNS
     mdns_shutdown(&port->mdns_info);
 #endif /* DO_MDNS */
@@ -480,6 +482,13 @@ myconfig(port_info_t *port, struct absout *eout, const char *pos)
 	port->led_tx = find_led(val);
 	if (!port->led_tx) {
 	    eout->out(eout, "Could not find led-tx LED: %s", val);
+	    return -1;
+	}
+    } else if (gensio_check_keyvalue(pos, "led-conn", &val) > 0) {
+	/* LED for UART Connection */
+	port->led_conn = find_led(val);
+	if (!port->led_conn) {
+	    eout->out(eout, "Could not find led-conn LED: %s", val);
 	    return -1;
 	}
     } else if (gensio_check_keybool(pos, "telnet-brk-on-sync",
@@ -686,6 +695,7 @@ init_port_data(port_info_t *port, struct absout *eout)
 
     port->led_tx = NULL;
     port->led_rx = NULL;
+    port->led_conn = NULL;
 
 #ifdef DO_MDNS
     mdns_info_getdefaults(&port->mdns_info, port->name, eout);

--- a/ser2net.yaml
+++ b/ser2net.yaml
@@ -77,6 +77,13 @@ define: &confver 1.0
 #   options:
 #     device: "tpacpi::standby"
 
+# # Create a steady state LED to indicate when a user is connected to the port
+# led: &led2
+#   driver: sysfs
+#   options:
+#     mode: "solid"
+#     device: "connled"
+
 # # This creates an arbitrary string we will use inside other strings.
 # # The quotes are necessary to keep YAML from interpreting the colons.
 # define: &serbase "/dev/serial/by-path/pci-0000:00:1d.0"

--- a/ser2net.yaml
+++ b/ser2net.yaml
@@ -105,6 +105,7 @@ define: &confver 1.0
 #     banner: *banner1
 #     led-tx: *led1
 #     led-rx: *led1
+#     led-conn: *led2
 
 # # A connection on
 # #  /dev/serial/by-path/pci-0000:00:1d.0-usb-0:1.8.2.4:1.0-port1

--- a/ser2net.yaml.5
+++ b/ser2net.yaml.5
@@ -471,6 +471,11 @@ use the previously defined led to indicate serial rx traffic on this
 port.  For version 2 this should be a YAML alias, like *led2.  For
 version 2 just use the name, like led2.
 
+.I led-conn: <led-alias>
+use the previously defined led to indicate as user is connected to the
+port.  For version 2 this should be a YAML alias, like *led2.  For
+version 2 just use the name, like led2.
+
 .I max-connections: <number>
 set the maximum number of connections that can be made on this particular
 TCP port.  If you make more than one connection to the same port, each
@@ -920,6 +925,9 @@ The time in milliseconds to flash the LED.  Defaults to 10.
 .I state: <number>
 The value to set the LED to to enable it.  Defaults to 1, but may need
 to be a different value.
+
+.I mode: <transient or solid>
+Sets the led mode as transient to flash or solid for a simple on-off mode.
 
 You reference the LED by alias in the connection options section, see
 that for details.  Make sure you have "modprobe ledtrig-transient"


### PR DESCRIPTION
    Ser2net already supports led-tx and led-rx for activity.  Add a new
    led-conn which gets enabled on connect and disabled on disconnect.
    A new type attribute is added to the led definition which can be either
    "static" or "flash".  Activity leds would flash where a connection led
    would be static.

    Yaml config:

    led: &led1
      driver: sysfs
      options:
        type: "static"
        device: "connled"

     connection: &con1
       accepter: telnet(rfc2217),tcp,2002
       timeout: 0
       enable: off
       connector: serialdev,*(serUSB0)-port0
       options:
         banner: *banner1
         led-conn: *led1